### PR TITLE
Update CORS policy to include localhost and fix duplicate

### DIFF
--- a/Hermes/Configs/Cors/CorsConfiguration.cs
+++ b/Hermes/Configs/Cors/CorsConfiguration.cs
@@ -10,7 +10,8 @@
                 {
                     builder.WithOrigins(
                             "https://casacamilodelelis.org",
-                            "https://static.cloudflareinsights.com"
+                            "https://static.cloudflareinsights.com",
+                            "http://localhost:5173"
                         )
                         .AllowAnyMethod()
                         .AllowAnyHeader()


### PR DESCRIPTION
Added `http://localhost:5173` to the `AllowSpecificOrigins` CORS policy to support local development. Removed a duplicate entry for `https://static.cloudflareinsights.com` to clean up the configuration.